### PR TITLE
Fix AGL build warnings due to missing autobuild scripts

### DIFF
--- a/autobuild/agl/autobuild
+++ b/autobuild/agl/autobuild
@@ -1,0 +1,58 @@
+#!/usr/bin/make -f
+# Copyright (C) 2015 - 2018 "IoT.bzh"
+# Author "Romain Forlot" <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	 http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+THISFILE  := $(lastword $(MAKEFILE_LIST))
+BUILD_DIR := $(abspath $(dir $(THISFILE))/../../build)
+DEST      := ${BUILD_DIR}
+
+.PHONY: all clean distclean configure build package help
+
+all: help
+
+help:
+	@echo "List of targets available:"
+	@echo ""
+	@echo "- all"
+	@echo "- clean"
+	@echo "- distclean"
+	@echo "- configure"
+	@echo "- build: compilation, link and prepare files for package into a widget"
+	@echo "- package: output a widget file '*.wgt'"
+	@echo "- install: install in your INSTALL_ROOT directory"
+	@echo ""
+	@echo "Usage: ./autobuild/agl/autobuild package DEST=${HOME}/opt"
+	@echo "Don't use your build dir as DEST as wgt file is generated at this location"
+
+clean:
+	@([ -d ${BUILD_DIR} ] && make -C ${BUILD_DIR} ${CLEAN_ARGS} clean) || echo Nothing to clean
+
+distclean:
+	@([ -d ${BUILD_DIR} ] && make -C ${BUILD_DIR} distclean) || echo Nothing to distclean
+
+configure:
+	@[ -d ${BUILD_DIR} ] || mkdir -p ${BUILD_DIR}
+	@[ -f ${BUILD_DIR}/Makefile ] || (cd ${BUILD_DIR} && qmake ${CONFIGURE_ARGS} ..)
+
+build: configure
+	@make -C ${BUILD_DIR} ${BUILD_ARGS} all
+
+package: build
+	@if [ "${DEST}" != "${BUILD_DIR}/$@" ]; then \
+		mkdir -p ${DEST} && cp ${BUILD_DIR}/$@/*.wgt ${DEST}; \
+	fi
+
+install: build
+	@make -C ${BUILD_DIR} ${INSTALL_ARGS} install

--- a/autobuild/linux/autobuild
+++ b/autobuild/linux/autobuild
@@ -1,0 +1,62 @@
+#!/usr/bin/make -f
+# Copyright (C) 2015 - 2018 "IoT.bzh"
+# Author "Romain Forlot" <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+THISFILE  := $(lastword $(MAKEFILE_LIST))
+BUILD_DIR := $(abspath $(dir $(THISFILE))/../../build)
+DEST      := ${BUILD_DIR}
+
+.PHONY: all clean distclean configure build package help
+
+all: help
+
+help:
+	@echo "List of targets available:"
+	@echo ""
+	@echo "- all"
+	@echo "- clean"
+	@echo "- distclean"
+	@echo "- configure"
+	@echo "- build: compilation, link and prepare files for package into a widget" 
+	@echo "- package: output a widget file '*.wgt'"
+	@echo "- install: install in your defined DEST directory"
+	@echo ""
+	@echo "Usage: ./autobuild/agl/autobuild package DEST=${HOME}/opt"
+	@echo "Don't use your build dir as DEST as wgt file is generated at this location" 
+
+clean:
+	@([ -d ${BUILD_DIR} ] && make -C ${BUILD_DIR} ${CLEAN_ARGS} clean) || echo Nothing to clean
+
+distclean:
+	@[ -d ${DEST} ] && find ${DEST} -name "*.wgt" -delete
+	@([ -d ${BUILD_DIR} ] && make -C ${BUILD_DIR} distclean) || echo Nothing to distclean
+
+configure:
+	@[ -d ${BUILD_DIR} ] || mkdir -p ${BUILD_DIR}
+	@[ -f ${BUILD_DIR}/Makefile ] || (cd ${BUILD_DIR} && qmake ${CONFIGURE_ARGS} ..)
+
+build: configure
+	@make -C ${BUILD_DIR} ${BUILD_ARGS} all
+
+package: build
+	@if [ "${DEST}" != "${BUILD_DIR}/$@" ]; then \
+		mkdir -p ${DEST} && cp ${BUILD_DIR}/$@/*.wgt ${DEST}; \
+	fi
+
+install: build
+	@if [ "${DEST}" != "${BUILD_DIR}" ]; then \
+		mkdir -p ${DEST} && cp -rf ${BUILD_DIR}/package/root/* ${DEST}; \
+	fi
+


### PR DESCRIPTION
This commit addresses AGL build warnings due to missing autobuild scripts.
It adds the script to silence the warnings for yocto based build as well as
the script to silence the warnings for sdk based build.

Bug-AGL: SPEC-2164
Signed-off-by: Raquel Medina <raquel.medina@konsulko.com>